### PR TITLE
Do not treat unknown build status as changed

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -219,7 +219,9 @@ fn run_observers(
                             .entry(&observer.info().id)
                             .or_insert(BuildStatus::Unknown);
                         let current_status = state.builds.current_status_for_collectors(collectors);
-                        if *previous_status != current_status {
+                        if *previous_status != current_status
+                            && *previous_status != BuildStatus::Unknown
+                        {
                             // Status changed so send this to the observer.
                             propagate_to_observer(
                                 observer,


### PR DESCRIPTION
New builds were getting treated as changed builds which
meant that their "new" status was sent to subscribing observers.

Closes #31