### PR TITLE
Do not duplicate same build from two collectors

### DIFF
--- a/src/builds.rs
+++ b/src/builds.rs
@@ -8,6 +8,7 @@ pub struct Build {
     pub id: u64,
     #[builder(setter(skip))]
     pub partition: u64,
+    pub origin: String,
     pub build_id: String,
     pub provider: BuildProvider,
     pub collector: String,
@@ -33,6 +34,7 @@ impl BuildBuilder {
         BuildBuilder::new()
             .build_id("foo")
             .provider(BuildProvider::TeamCity)
+            .origin("origin")
             .collector("collector")
             .project_id("project_id")
             .project_name("project_name")
@@ -49,6 +51,7 @@ impl BuildBuilder {
     pub fn build(&self) -> Result<Build, String> {
         let build_id = Clone::clone(self.build_id.as_ref().ok_or("Build ID is missing")?);
         let provider = Clone::clone(self.provider.as_ref().ok_or("Build provider is missing")?);
+        let origin = Clone::clone(self.origin.as_ref().ok_or("Origin is missing")?);
         let collector = Clone::clone(self.collector.as_ref().ok_or("Collector is missing")?);
         let project_id = Clone::clone(self.project_id.as_ref().ok_or("Project ID is missing")?);
         let project_name = Clone::clone(
@@ -80,7 +83,7 @@ impl BuildBuilder {
         // Generate a hash that represents the build.
         let mut hasher = DefaultHasher::new();
         provider.hash(&mut hasher);
-        collector.hash(&mut hasher);
+        origin.hash(&mut hasher);
         project_id.hash(&mut hasher);
         definition_id.hash(&mut hasher);
         branch.hash(&mut hasher);
@@ -91,7 +94,7 @@ impl BuildBuilder {
         // definition (partition) of the build, not the build itself.
         let mut hasher = DefaultHasher::new();
         provider.hash(&mut hasher);
-        collector.hash(&mut hasher);
+        origin.hash(&mut hasher);
         project_id.hash(&mut hasher);
         definition_id.hash(&mut hasher);
         branch.hash(&mut hasher);
@@ -102,6 +105,7 @@ impl BuildBuilder {
             partition,
             build_id,
             provider,
+            origin,
             collector,
             project_id,
             project_name,

--- a/src/engine/state/builds.rs
+++ b/src/engine/state/builds.rs
@@ -80,14 +80,13 @@ impl BuildRepository {
             }
         }
 
-        // Remove the build from the list
+        // Remove the build from the list and add it again.
         builds.retain(|b| {
             !(b.collector == build.collector
                 && b.project_id == build.project_id
                 && b.definition_id == build.definition_id
                 && b.build_id == build.build_id)
         });
-
         builds.push(build.clone());
 
         return result;

--- a/src/providers/collectors/azure/mod.rs
+++ b/src/providers/collectors/azure/mod.rs
@@ -58,6 +58,7 @@ impl Collector for AzureDevOpsCollector {
                     BuildBuilder::new()
                         .build_id(build.id.to_string())
                         .provider(BuildProvider::AzureDevOps)
+                        .origin(format!("{}/{}", &self.client.organization, &self.client.project))
                         .collector(&self.info.id)
                         .project_id(&build.project.id)
                         .project_name(&build.project.name)

--- a/src/providers/collectors/github/mod.rs
+++ b/src/providers/collectors/github/mod.rs
@@ -60,6 +60,10 @@ impl<T: HttpClient + Default> Collector for GitHubCollector<T> {
                 BuildBuilder::new()
                     .build_id(run.id.to_string())
                     .provider(BuildProvider::GitHub)
+                    .origin(format!(
+                        "{}/{}/{}",
+                        &self.client.owner, &self.client.repository, &self.client.workflow
+                    ))
                     .collector(&self.info.id)
                     .project_id(format!(
                         "{}_{}",

--- a/src/providers/collectors/octopus/mod.rs
+++ b/src/providers/collectors/octopus/mod.rs
@@ -91,6 +91,7 @@ impl Collector for OctopusDeployCollector {
                     BuildBuilder::new()
                         .build_id(&deployment.id)
                         .provider(BuildProvider::OctopusDeploy)
+                        .origin(self.server_url.as_str())
                         .collector(&self.info.id)
                         .project_id(&found_project.id)
                         .project_name(&found_project.name)

--- a/src/providers/collectors/teamcity/mod.rs
+++ b/src/providers/collectors/teamcity/mod.rs
@@ -89,6 +89,7 @@ impl Collector for TeamCityCollector {
                             BuildBuilder::new()
                                 .build_id(build.id.to_string())
                                 .provider(BuildProvider::TeamCity)
+                                .origin(self.client.url.as_str())
                                 .collector(&self.info.id)
                                 .project_id(&found.project_id)
                                 .project_name(&found.project_name)


### PR DESCRIPTION
Fixed a bug where the same build returned by two different collectors was added twice to Duck's build state.