### PR TITLE
Add command to validate configuration

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,2 +1,3 @@
 pub mod schema;
 pub mod start;
+pub mod validate;

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use structopt::StructOpt;
+
+use super::start::DEFAULT_CONFIG;
+use duck::DuckResult;
+
+///////////////////////////////////////////////////////////
+// Arguments
+
+#[derive(StructOpt, Debug)]
+pub struct Arguments {
+    /// The configuration file
+    #[structopt(
+        short,
+        long,
+        parse(from_os_str),
+        default_value = DEFAULT_CONFIG,
+        env = "DUCK_CONFIG"
+    )]
+    pub config: PathBuf,
+}
+
+///////////////////////////////////////////////////////////
+// Command
+
+pub async fn execute(args: Arguments) -> DuckResult<()> {
+    duck::validate_config(args.config).await?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,3 +65,12 @@ pub fn get_schema() -> String {
     let schema = gen.into_root_schema_for::<config::Configuration>();
     serde_json::to_string_pretty(&schema).unwrap()
 }
+
+///////////////////////////////////////////////////////////
+// Validate
+
+pub async fn validate_config<T: Into<PathBuf>>(config_path: T) -> DuckResult<()> {
+    // Load and validate the configuration file.
+    Configuration::from_file(&EnvironmentVariableProvider::new(), config_path.into())?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ enum Command {
     Start(commands::start::Arguments),
     /// Generates the JSON schema
     Schema(commands::schema::Arguments),
+    /// Validates the Duck configuration
+    Validate(commands::validate::Arguments),
 }
 
 impl Command {
@@ -50,6 +52,7 @@ impl Command {
         match self {
             Command::Start(_) => true,
             Command::Schema(_) => false,
+            Command::Validate(_) => false,
         }
     }
 }
@@ -72,6 +75,7 @@ async fn main() {
     let result = match args.command {
         Command::Start(args) => commands::start::execute(args).await,
         Command::Schema(args) => commands::schema::execute(args).await,
+        Command::Validate(args) => commands::validate::execute(args).await,
     };
 
     // Return the correct exit code


### PR DESCRIPTION
This commit adds a new command `validate` that checks whether
or not the configuration is valid and reports any errors to
the user.

Closes #52